### PR TITLE
Example for issue 28

### DIFF
--- a/test/issue28
+++ b/test/issue28
@@ -1,0 +1,23 @@
+       Ctl-Opt BndDir('NOXDB') dftactgrp(*NO) ACTGRP(*NEW);            
+      /COPY QRPGLEREF,JSONPARSER                                       
+       Dcl-S pJson        Pointer;                                     
+       Dcl-S refVal     Varchar(50);                                   
+       Dcl-S pResult    Varchar(1024);                                 
+       Dcl-S stringVar  Varchar(2000);                                 
+                                                                       
+       stringVar = '{   "$ref" : "#/components/schemas/OMCUSRSP"  }';  
+       pJson = Json_ParseString(stringVar);                            
+       if Json_Error(pJson) ;                                          
+         pResult = Json_Message(pJson);                                
+         Json_dump(pJson);                                             
+         Json_Close(pJson);                                            
+         *InLr = *On;                                                  
+         Return;                                                       
+       EndIf;                                                          
+       refVal = Json_GetStr(pJson: '$ref');                            
+       If refval = *blanks;                                            
+         dsply '*Blanks';                                              
+       else;                                                           
+         dsply refVal;                                                 
+       endif;                                                          
+       *Inlr = *On;                                                    


### PR DESCRIPTION
To test compile this example and run with the two different versions of noxDB

  git checkout f0a1e752e7ab12932f511bccd5302ceb144d14f5 -f
  gmake
 <run example SUCCESS>

  git checkout e708612b057c7d3818ac3057bbc3c1d8fa76ae4e -f
  gmake
 <run example FAIL>


